### PR TITLE
Script after sync

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: twinkle
 Title: Provision Shiny Applications
-Version: 2.0.0
+Version: 2.0.1
 Authors@R: c(person("Wes", "Hinsley", role = c("aut", "cre"),
                     email = "w.hinsley@imperial.ac.uk"),
              person("Rich", "FitzJohn", role = "aut",

--- a/R/config.R
+++ b/R/config.R
@@ -26,7 +26,7 @@ read_config <- function(path_config) {
 
 check_app_config <- function(name, cfg) {
   required <- c("username", "repo")
-  allowed <- c(required, "branch", "subdir", "private")
+  allowed <- c(required, "branch", "subdir", "private", "script")
   msg <- setdiff(required, names(cfg))
   if (length(msg) > 0) {
     cli::cli_abort("Required fields missing in 'site.yml:apps:{name}': {msg}")

--- a/R/utils.R
+++ b/R/utils.R
@@ -46,3 +46,26 @@ sys_getenv <- function(name) {
 last <- function(x) {
   x[[length(x)]]
 }
+
+
+run_script <- function(path, filename, verbose = TRUE) {
+  if (grepl("\\.[rR]", filename)) {
+    cmd <- find_rscript()
+    args <- filename
+  } else {
+    cmd <- paste0("./", filename)
+    args <- character()
+  }
+
+  withr::local_dir(path)
+  if (!file.exists(filename)) {
+    cli::cli_abort("Did not find script '{filename}' (within '{path}')")
+  }
+
+  system2_or_throw(cmd, args, verbose = verbose)
+}
+
+
+find_rscript <- function() {
+  file.path(R.home(), "bin", "Rscript")
+}

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ where `apache` presents the interface to the world and looks after https, `hapro
 
 We like this setup, compared with something like [shinyproxy](https://shinyproxy.io/) where balancing occurs **between applications** but multiple users of the same appliation compete (this at least [used to be the case](https://support.openanalytics.eu/t/more-than-one-user-per-container/373)).  In our experience, multiple users tend to correlate on the **same** application, e.g., when running a workshop or after launching an app related to a new publication.
 
-We are reasonably agnostic about how deployments are configured, and the actual configuration is fairly basic; see [`shiny-dev`](https://github.com/reside-ic/shiny-dev/tree/docker-compose) for a full example using `docker compose` and minimal configuration for the three services above.
+We are reasonably agnostic about how deployments are configured, and the actual configuration is fairly basic; see [`shiny-dev`](https://github.com/reside-ic/shiny-dev) for a full example using `docker compose` and minimal configuration for the three services above.
 
 We then imagine some persistant storage (such as a docker volume) holding all the data for applications; this is where `shiny` will serve from but also some persistant storage that we need in order to set the applications up.  The `reside-ic/twinkle` container contains a cli application `twinkle` that can perform simple administrative commands based on a configuration that describes the applications.
 
@@ -48,6 +48,14 @@ The valid fields within each application are:
 * `branch`: optionally the branch to deploy.  By default we will use the default branch from github (i.e., the one that you see when you navigate to the github landing page and the branch that is checked out by default on clone)
 * `subdir`: the subdirectory within the repo where the application itself can be found.  It is reasonably common that the application might be found somewhere other than the root; packages often use `inst/app` and sometimes a shiny app is part of a larger repository.  The application can be stored anywhere within the repo, but it may not reference files above the subdirectory while it runs
 * `private`: a boolean indicating if the repository is private. If so, you will need to add a deploy key to the repository in order to clone it over ssh
+* `script`: an optional script to run after the app has been sync-ed to the destination (either staging or production).
+
+The intention for use of `script` is for apps that are installed into a directory that is read-only at app runtime, which is the case in [`shiny-dev`](https://github.com/reside-ic/shiny-dev) so that we can safely run many workers on the same tree.  This causes issues where it is convenient to have the code in the application perform some calculation after cloning but before running.  Examples that we have seen where this was used (or could have been used) are:
+
+* downloading some data that is not able to be stored in the git repository
+* prerending rmarkdown for use with `learnr`
+
+Note that (at least at present) this script is run separately after the sync to staging and to production, so ideally the script should be deterministic or you will see slightly different results.  It is possible that we could change things to allow sync to production to occur from staging (rather from the sources) but that requires that we always update source/lib, then staging, then production.
 
 # Packages
 
@@ -76,7 +84,7 @@ The precedence order is `conan.R` (highest precedence), then `pkgdepends.txt`, t
 
 # Interaction
 
-Here, we assume the exact setup used in [`shiny-dev`](https://github.com/reside-ic/shiny-dev/tree/docker-compose), and we assume that the system is running (i.e., `docker compose ps` shows services running).
+Here, we assume the exact setup used in [`shiny-dev`](https://github.com/reside-ic/shiny-dev), and we assume that the system is running (i.e., `docker compose ps` shows services running).
 
 You should be able to run
 
@@ -118,4 +126,4 @@ We assume that three environment variables are set
 * `TWINKLE_LOGS`: points at the location that the logs will be written
 * `TWINKLE_CONFIG`: points at the location of the configuration
 
-In the [`shiny-dev`](https://github.com/reside-ic/shiny-dev/tree/docker-compose) setup, we set these in the compose file, bind-mounting the configuration in from the host and using a docker volume for the root, shared among all workers.  Practicaly, the server configuration needs to kept in sync with this configuration, with `site_dir` set to `${TWINKLE_ROOT}/apps`
+In the [`shiny-dev`](https://github.com/reside-ic/shiny-dev) setup, we set these in the compose file, bind-mounting the configuration in from the host and using a docker volume for the root, shared among all workers.  Practicaly, the server configuration needs to kept in sync with this configuration, with `site_dir` set to `${TWINKLE_ROOT}/apps`

--- a/README.md
+++ b/README.md
@@ -126,4 +126,4 @@ We assume that three environment variables are set
 * `TWINKLE_LOGS`: points at the location that the logs will be written
 * `TWINKLE_CONFIG`: points at the location of the configuration
 
-In the [`shiny-dev`](https://github.com/reside-ic/shiny-dev) setup, we set these in the compose file, bind-mounting the configuration in from the host and using a docker volume for the root, shared among all workers.  Practicaly, the server configuration needs to kept in sync with this configuration, with `site_dir` set to `${TWINKLE_ROOT}/apps`
+In the [`shiny-dev`](https://github.com/reside-ic/shiny-dev) setup, we set these in the compose file, bind-mounting the configuration in from the host and using a docker volume for the root, shared among all workers.  Practically, the server configuration needs to be kept in sync with this configuration, with `site_dir` set to `${TWINKLE_ROOT}/apps`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -54,4 +54,5 @@ RUN install2.r --error \
     && Rscript -e 'twinkle:::install_cli("/usr/local/bin")' \
     && cp /src/docker/delete-old-logs /usr/local/bin \
     && cp /src/docker/Rprofile /home/shiny/.Rprofile \
+    && cp /src/docker/Rprofile /root/.Rprofile \
     && rm -rf /src

--- a/man/twinkle_sync.Rd
+++ b/man/twinkle_sync.Rd
@@ -4,13 +4,17 @@
 \alias{twinkle_sync}
 \title{Sync app}
 \usage{
-twinkle_sync(name, production)
+twinkle_sync(name, production, verbose = TRUE)
 }
 \arguments{
 \item{name}{Name of the app}
 
 \item{production}{Logical, indicating if we want to update the
 production instance.  If \code{FALSE}, then staging is updated.}
+
+\item{verbose}{Logical, indicating if output should be shown
+(passed to system commands, which are otherwise hard to capture
+output from)}
 }
 \value{
 A named character vector with the ids of the repo (last

--- a/tests/testthat/test-config.R
+++ b/tests/testthat/test-config.R
@@ -77,3 +77,24 @@ test_that("can read a private application", {
                                 subdir = "foo",
                                 name = "foo"))))
 })
+
+
+test_that("can have a post-sync script", {
+  path <- withr::local_tempfile()
+  writeLines(
+    c("apps:",
+      "  foo:",
+      "    username: bob",
+      "    repo: app",
+      "    script: whatever.R"),
+    path)
+  dat <- read_app_config(path, "foo")
+  expect_equal(
+    dat,
+    list(username = "bob",
+         repo = "app",
+         script = "whatever.R",
+         branch = NULL,
+         private = FALSE,
+         name = "foo"))
+})

--- a/tests/testthat/test-twinkle.R
+++ b/tests/testthat/test-twinkle.R
@@ -171,7 +171,9 @@ test_that("Can call sync on staging", {
   twinkle_sync("myapp", FALSE)
 
   args <- mockery::mock_args(mock_sync_app)[[1]]
-  expect_equal(args, list("myapp", "inner", production = FALSE, root = root))
+  expect_equal(
+    args,
+    list("myapp", "inner", production = FALSE, root = root, verbose = TRUE))
 })
 
 
@@ -189,7 +191,9 @@ test_that("Can call sync on production", {
   twinkle_sync("myapp", TRUE)
 
   args <- mockery::mock_args(mock_sync_app)[[1]]
-  expect_equal(args, list("myapp", "inner", production = TRUE, root = root))
+  expect_equal(
+    args,
+    list("myapp", "inner", production = TRUE, root = root, verbose = TRUE))
 })
 
 

--- a/tests/testthat/test-util.R
+++ b/tests/testthat/test-util.R
@@ -26,6 +26,47 @@ test_that("can run a command, failing if it does not succeed", {
 })
 
 
+test_that("can run a command, failing if it does not succeed", {
+  expect_no_error(system2_or_throw("true", character()))
+  expect_error(system2_or_throw("false", character()),
+               "Command failed with exit code 1")
+})
+
+
+test_that("throw if script not found", {
+  tmp <- withr::local_tempdir()
+  filename <- "script.R"
+
+  expect_error(
+    run_script(tmp, filename),
+    "Did not find script 'script\\.R' \\(within '.+'\\)")
+})
+
+
+test_that("can run a script", {
+  mock_run <- mockery::mock()
+  mockery::stub(run_script, "system2_or_throw", mock_run)
+
+  tmp <- withr::local_tempdir()
+
+  filename1 <- "script.R"
+  file.create(file.path(tmp, filename1))
+
+  run_script(tmp, filename1)
+  mockery::expect_called(mock_run, 1)
+  expect_equal(mockery::mock_args(mock_run)[[1]],
+               list(find_rscript(), "script.R", verbose = TRUE))
+
+  filename2 <- "script"
+  file.create(file.path(tmp, filename2))
+
+  run_script(tmp, filename2)
+  mockery::expect_called(mock_run, 2)
+  expect_equal(mockery::mock_args(mock_run)[[2]],
+               list("./script", character(), verbose = TRUE))
+})
+
+
 test_that("can require an environment variable is present", {
   withr::with_envvar(c(FOO = NA_character_, BAR = "hello"), {
     expect_error(sys_getenv("FOO"),


### PR DESCRIPTION
This is the missing piece that will help with Shazia's app (probably now redundant but it will be a good model to have because Bob may want something like this again).  See the docs in README for details.

Because the script runs as root (we run shiny server as `shiny` but that's at the level of the shiny config, not the container's primary user) we need to also copy the Rprofile file over to root's home so that they get the library lookup; that is generally a useful thing for us