### PR TITLE
More explicit error if repo has changed location

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: twinkle
 Title: Provision Shiny Applications
-Version: 2.0.1
+Version: 2.0.2
 Authors@R: c(person("Wes", "Hinsley", role = c("aut", "cre"),
                     email = "w.hinsley@imperial.ac.uk"),
              person("Rich", "FitzJohn", role = "aut",

--- a/R/repo.R
+++ b/R/repo.R
@@ -2,14 +2,15 @@ repo_update <- function(name, username, repo, branch, private, root,
                         verbose = TRUE) {
   dest <- path_repo(root, name)
   key <- repo_key(root, name, private)
+  url <- repo_url(username, repo, private)
   if (!file.exists(dest)) {
     cli::cli_h1("Cloning {name} (from github: {username}/{repo})")
     dir_create(dirname(dest))
-    gert::git_clone(repo_url(username, repo, private), dest,
-                    ssh_key = key, verbose = verbose)
+    gert::git_clone(url, dest, ssh_key = key, verbose = verbose)
     repo_checkout_branch(name, branch, root)
   } else {
     cli::cli_h1("Updating sources for {name}")
+    repo_check_remote(dest, url)
     gert::git_fetch(repo = dest, ssh_key = key, verbose = verbose)
   }
   repo_update_lfs(dest)
@@ -84,6 +85,18 @@ repo_key <- function(root, name, private) {
       i = "You might run {.code ./twinkle deploy-key {name}}")
   }
   path
+}
+
+
+repo_check_remote <- function(path, url) {
+  prev <- gert::git_remote_info("origin", repo = path)$url
+  if (!identical(prev, url)) {
+    cli::cli_abort(
+      c("Remote url has changed, can't update sources",
+        i = "Previous: {prev}",
+        i = "Current: {url}",
+        i = "You should delete the application and try again"))
+  }
 }
 
 

--- a/R/repo.R
+++ b/R/repo.R
@@ -81,8 +81,8 @@ repo_key <- function(root, name, private) {
   path <- path_deploy_key(root, name)
   if (!file.exists(path)) {
     cli::cli_abort(
-      "Deploy key for '{name}' does not exist yet",
-      i = "You might run {.code ./twinkle deploy-key {name}}")
+      c("Deploy key for '{name}' does not exist yet",
+        i = "You might run {.code ./twinkle deploy-key {name}}"))
   }
   path
 }

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -19,6 +19,7 @@ RUN apt-get update && apt-get install -y \
     libgdal-dev \
     libgeos-dev \
     libglpk-dev \
+    libnode-dev \
     libproj-dev \
     libsodium-dev \
     libudunits2-dev \

--- a/tests/testthat/test-repo.R
+++ b/tests/testthat/test-repo.R
@@ -174,3 +174,19 @@ test_that("private repos need repo keys", {
   file.create(path_key)
   expect_equal(repo_key(path, "app", TRUE), path_key)
 })
+
+
+test_that("can error if the repo url changes", {
+  path <- withr::local_tempdir()
+  sha <- create_simple_git_repo(path)
+  url <- "https://example.com/git"
+  gert::git_remote_add(url, repo = path)
+
+  expect_no_error(repo_check_remote(path, url))
+  expect_error(
+    repo_check_remote(path, "git@example.com/git"),
+    "Remote url has changed, can't update sources")
+  expect_error(
+    repo_check_remote(path, "https://github.com/user/repo"),
+    "Remote url has changed, can't update sources")
+})

--- a/tests/testthat/test-repo.R
+++ b/tests/testthat/test-repo.R
@@ -9,6 +9,10 @@ test_that("can clone project", {
 
 
 test_that("can update a git mirror to track upstream", {
+  skip_if_not_installed("mockery")
+  mock_check_remote <- mockery::mock()
+  mockery::stub(repo_update, "repo_check_remote", mock_check_remote)
+
   upstream <- withr::local_tempdir()
   root <- withr::local_tempdir()
   name <- "foo"
@@ -39,10 +43,19 @@ test_that("can update a git mirror to track upstream", {
   suppressMessages(
     repo_update(name, user, repo, NULL, FALSE, root, verbose = FALSE))
   expect_equal(gert::git_info(dest)$commit, sha3)
+
+  mockery::expect_called(mock_check_remote, 2)
+  expect_equal(
+    mockery::mock_args(mock_check_remote),
+    rep(list(list(dest, "https://github.com/user/repo")), 2))
 })
 
 
 test_that("can update a git mirror to track upstream", {
+  skip_if_not_installed("mockery")
+  mock_check_remote <- mockery::mock()
+  mockery::stub(repo_update, "repo_check_remote", mock_check_remote)
+
   upstream <- withr::local_tempdir()
   root <- withr::local_tempdir()
   name <- "foo"


### PR DESCRIPTION
I documented this in shiny-dev but I think that throwing an error will make it much easier to understand in practice.

Also includes a few fixes found when setting up the dide server:

* add libnode to the image
* fix error message in deploy key prompt